### PR TITLE
Remove redundant list styles

### DIFF
--- a/src/runtime/styles/cut.scss
+++ b/src/runtime/styles/cut.scss
@@ -50,16 +50,4 @@ details.yfm-cut > .yfm-cut-content {
             transform: translateY(-50%);
         }
     }
-
-    .yfm:not(.yfm_no-list-reset) & ol {
-        counter-reset: cut-list;
-
-        & > li {
-            counter-increment: cut-list;
-
-            &::before {
-                content: counters(cut-list, '.') '. ';
-            }
-        }
-    }
 }


### PR DESCRIPTION
Styles removed were previously made redundant by diplodoc-platform/transform#628.