### PR TITLE
fix: make cute title text selectable

### DIFF
--- a/src/runtime/styles/cut.scss
+++ b/src/runtime/styles/cut.scss
@@ -20,7 +20,6 @@ details.yfm-cut > .yfm-cut-content {
         list-style: none;
         cursor: pointer;
         position: relative;
-        user-select: none;
         padding: 5px 0 5px 30px;
 
         &::-webkit-details-marker {


### PR DESCRIPTION
From https://github.com/diplodoc-platform/transform/issues/449

> **Problem**: Now, I can't select text inside cut title and copy It to clipboard.
> **Profit for users**: If we make text in cut title selectable, It helps usual users work with text simpler.
> **Potential problems**: Maybe, It was done because cut title is clickable and somehow it affects opening/closing cut.