### PR TITLE
fix(styles): fixed float handling in content

### DIFF
--- a/src/runtime/styles/cut.scss
+++ b/src/runtime/styles/cut.scss
@@ -41,6 +41,7 @@ details.yfm-cut > .yfm-cut-content {
     }
 
     &-content {
+        overflow: auto;
         padding: 5px 0 15px 30px;
     }
 

--- a/src/runtime/styles/cut.scss
+++ b/src/runtime/styles/cut.scss
@@ -4,7 +4,6 @@ details.yfm-cut > .yfm-cut-content {
 
 .yfm-cut {
     $class: &;
-    $accentColor: red;
     transition: all 150ms;
 
     margin-bottom: 15px;


### PR DESCRIPTION
Added `overflow: auto` to `.yfm-cut-content` to prevent height collapse when floated elements are present and avoid the need for clearfix.